### PR TITLE
Fix ordered list number wrapping

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -195,15 +195,14 @@ ol > li:not(.task-list-item)::before,
 ul ol > li:not(.task-list-item)::before,
 ul ul ol > li:not(.task-list-item)::before,
 ul ul ul ol > li:not(.task-list-item)::before {
-    content: "." counter(li);
+    content: counter(li) ".";
     color:  var(--accent-2);
-    font-weight:normal;
+    font-weight: normal;
     display: inline-block;
-    width: 1em;
-    margin-left: -1.5em;
+    margin-left: -2.5em;
     margin-right: 0.5em;
+    width: 2em;
     text-align: right;
-    direction: rtl;
     word-wrap: none;
     overflow: visible;
     word-break: keep-all;


### PR DESCRIPTION
List numbering alignment fix.  See issue #4.

Related to the issue, I realise now that the text colour on the buttons is light theme related and I'm using it in dark mode, so I guess that's my issue.

As for the list numbers, I think the change I'm introducing here makes the alignment nicer and it looks good for `n>1` digits (see screenshot).

![numbered list](https://user-images.githubusercontent.com/2369197/92418867-2eaae300-f16a-11ea-95bc-542ad36f67d4.png)
