### PR TITLE
Apply theme colours to code 

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -218,6 +218,10 @@ code {
   color: var(--accent-1);
 }
 
+.markdown-preview-view code {
+  color: var(--accent-1)
+}
+
 pre code {
   color: var(--text-normal);
 }

--- a/obsidian.css
+++ b/obsidian.css
@@ -222,6 +222,10 @@ code {
   color: var(--accent-1)
 }
 
+.cm-s-obsidian pre.HyperMD-codeblock {
+  color: var(--accent-6-muted);
+}
+
 pre code {
   color: var(--text-normal);
 }


### PR DESCRIPTION
This applies theme colours to inline code in preview and code blocks in editing. Inline preview code is `accent-1` and the code block body is `accent-6-muted`. Originally, they are left as a bright red (see #8)

Before:
![image](https://user-images.githubusercontent.com/7717434/95358664-34a6f780-08c1-11eb-87b3-7b92219dd522.png)

After:
![image](https://user-images.githubusercontent.com/7717434/95358699-3c669c00-08c1-11eb-97cc-d4fa0d2311ae.png)
