### PR TITLE
fix: remove apostrophe from theme name to match registry

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"name": "80's Neon",
+	"name": "80s Neon",
 	"version": "1.0.0",
 	"minAppVersion": "0.16.0",
 	"author": "death.au",


### PR DESCRIPTION
## Summary
  Fixes #27 - Resolves "Failed to install theme '80s Neon'. Theme name mismatch" error

  ## Problem
  When users try to install the theme via Obsidian's theme manager, installation fails with "Theme name mismatch" error.

  ## Root Cause
  The theme name in `manifest.json` contains an apostrophe (`"80's Neon"`), but the theme is registered in the Obsidian community themes registry as `"80s Neon"` (without apostrophe). Obsidian validates that these names match during installation.

  ## Solution
  Remove the apostrophe from the `name` field in `manifest.json` to match the registry entry.

  **Before:** `"name": "80's Neon"`
  **After:** `"name": "80s Neon"`

  ## References
  - Issue: #27
  - Commit that introduced the issue: 8d6217a (2025-12-28)
  - Registry entry: [community-css-themes.json](https://github.com/obsidianmd/obsidian-releases/blob/master/community-css-themes.json#L52-L58)